### PR TITLE
Port from QWebKit to QWebEngine

### DIFF
--- a/FlatFab.pro
+++ b/FlatFab.pro
@@ -43,6 +43,8 @@ HEADERS  += include/mainwindow.h \
     include/transformwidget.h \
     include/triangulate2.h
 
+INCLUDEPATH += include/
+
 #linux specific build settings
 unix:!macx:LIBS += -lGLU
 unix:!macx:QMAKE_LFLAGS +=  '-Wl,-rpath,\'\$$ORIGIN/libs\'' #this sets the RPATH to "libs" local to the executable location

--- a/FlatFab.pro
+++ b/FlatFab.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui opengl widgets webkit network webkitwidgets
+QT += core gui opengl widgets network webenginewidgets
 
 TARGET = FlatFab
 TEMPLATE = app

--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -2,7 +2,7 @@
 #define MAINWINDOW_H
 
 #include <QtGui>
-#include <QWebView>
+#include <QWebEngineView>
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
 #include <QNetworkReply>
@@ -217,7 +217,7 @@ private:
     QWidget * bottomWidget;
     QDockWidget * bottomDockWidget;
 
-    QWebView * webView;
+    QWebEngineView * webView;
 
 
     // New UI features

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QWebEngineSettings>
 #include "mainwindow.h"
 
 int main(int argc, char *argv[])
@@ -113,7 +114,5 @@ int main(int argc, char *argv[])
     w.show();
     
     return a.exec();
-
-    QWebSettings::clearMemoryCaches();
 
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,3 +1,5 @@
+#include <QWebEngineSettings>
+
 #include "mainwindow.h"
 
 MainWindow::MainWindow()
@@ -52,11 +54,11 @@ MainWindow::MainWindow()
     //dockWidget->setWidget(sideWidget);
 
     //web view stuff
-    webView = new QWebView(this);
+    webView = new QWebEngineView(this);
     webView->setGeometry(0,0,800,700);
 
     // --- does nothing for some reason
-    webView->settings()->setFontFamily(QWebSettings::SansSerifFont, "Arial");
+    webView->settings()->setFontFamily(QWebEngineSettings::SansSerifFont, "Arial");
     // ---
 
     webView->load(QUrl("http://flatfab.com/splash.html"));


### PR DESCRIPTION
QWebKit has been deprecated since Qt 5.6 and removed from more recent Qt. 